### PR TITLE
fix: correct environment variable name in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ Skills are registered in `skillRegistry` array in `src/agent/skillPolicy.ts` wit
 ## Configuration
 
 Required environment variables (see `.env.example`):
-- `ANTHROPIC_API_KEY` - For Claude API calls
+- `OPENROUTER_API_KEY` - For Claude API calls via OpenRouter
 - `GITHUB_TOKEN` - For GitHub API operations
 - `GITHUB_WEBHOOK_SECRET` - For webhook signature validation
 


### PR DESCRIPTION
## Summary

Fixes #4

The documentation in CLAUDE.md incorrectly referenced `ANTHROPIC_API_KEY` but the actual code uses `OPENROUTER_API_KEY` for the OpenRouter integration.

## Changes

- Updated environment variable name from `ANTHROPIC_API_KEY` to `OPENROUTER_API_KEY`
- Added clarification that it's for "Claude API calls via OpenRouter"

## Test Plan

- [x] Verified the fix matches the actual `.env.example` configuration
- [x] Verified the code in `src/agent/runAgent.ts` uses `OPENROUTER_API_KEY`

---
🤖 This fix was automatically generated by Agent Workflow Server