### PR TITLE
refactor: extract version to APP_VERSION constant

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -17,9 +17,14 @@
 import express, { Application, Request, Response } from 'express';
 import dotenv from 'dotenv';
 import { githubRouter } from './routes/github';
+// Import package.json to read version
+import packageInfo from '../package.json';
 
 // Load environment variables
 dotenv.config();
+
+// Extract version to constant
+const APP_VERSION = packageInfo.version;
 
 const app: Application = express();
 const PORT = process.env.PORT || 3000;
@@ -36,7 +41,7 @@ app.get('/health', (_req: Request, res: Response) => {
   res.json({
     status: 'ok',
     timestamp: new Date().toISOString(),
-    version: '1.0.0',
+    version: APP_VERSION,
   });
 });
 


### PR DESCRIPTION
## Summary

This PR addresses issue #7 by extracting the hardcoded version string to a constant `APP_VERSION` and using it in the health check response.

## Changes Made

- **Extract version constant**: Created `APP_VERSION` constant by importing version from `package.json`
- **Update health endpoint**: Modified `/health` endpoint to use `APP_VERSION` instead of hardcoded string
- **Maintain consistency**: Version now automatically syncs with `package.json` version

## Benefits

- ✅ **Single source of truth**: Version is now read from `package.json`
- ✅ **Better maintainability**: No need to manually update version in multiple places
- ✅ **Consistency**: Health endpoint version always matches package version
- ✅ **Follows best practices**: Extracted magic string to named constant

## Code Changes

```typescript
// Before
version: '1.0.0',

// After  
const APP_VERSION = packageInfo.version;
// ...
version: APP_VERSION,
```

## Test Plan

- [x] Run server with `npm run dev`
- [x] Check `/health` endpoint returns correct version from package.json
- [x] Verify TypeScript compilation works with JSON import

## Testing Instructions

1. Start the server: `npm run dev`
2. Visit `http://localhost:3000/health` 
3. Verify the response includes `"version": "1.0.0"` (matching package.json)

Resolves #7