### PR TITLE
refactor: extract version to constant

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -21,6 +21,11 @@ import { githubRouter } from './routes/github';
 // Load environment variables
 dotenv.config();
 
+// ===========================================
+// Constants
+// ===========================================
+const APP_VERSION = '1.0.0';
+
 const app: Application = express();
 const PORT = process.env.PORT || 3000;
 
@@ -36,7 +41,7 @@ app.get('/health', (_req: Request, res: Response) => {
   res.json({
     status: 'ok',
     timestamp: new Date().toISOString(),
-    version: '1.0.0',
+    version: APP_VERSION,
   });
 });
 


### PR DESCRIPTION
## Summary
- Extract version string to a constant `APP_VERSION`
- Use the constant in health check response

## Changes Made
- Added `APP_VERSION` constant at the top of the file
- Replaced hardcoded `'1.0.0'` string with `APP_VERSION` in health endpoint
- Improved code maintainability by following DRY principle

## Test Plan
- Run server and check `/health` endpoint returns correct version
- Version should still be `1.0.0` but now sourced from the constant

## Implementation Details
The version is now centralized in a single constant, making it easier to update in the future and ensuring consistency across the application.

Resolves #7